### PR TITLE
feat: Add start_date and end_date sorters (backend)

### DIFF
--- a/apps/openchallenges/challenge-service/requests.http
+++ b/apps/openchallenges/challenge-service/requests.http
@@ -52,7 +52,6 @@ GET {{basePath}}/challenges?minStartDate=2017-01-01&maxStartDate=2017-12-31
 
 GET {{basePath}}/challenges?inputDataTypes=genomic
 
-
 ### List the challenge that is categorized as featured
 
 GET {{basePath}}/challenges?categories=featured
@@ -62,17 +61,28 @@ GET {{basePath}}/challenges?categories=featured
 GET {{basePath}}/challenges?categories=starting_soon
 
 ### List the challenges that is categorized as ending soon.
+
 GET {{basePath}}/challenges?categories=ending_soon
 
 ### List the challenges that is categorized as recently started.
+
 GET {{basePath}}/challenges?categories=recently_started
 
 ### List the challenges that is categorized as recently ended .
+
 GET {{basePath}}/challenges?categories=recently_ended
 
 ### Sort the challenges by their starred count in desc order
 
 GET {{basePath}}/challenges?sort=starred&direction=desc
+
+### Sort the challenges by start date (desc by default)
+
+GET {{basePath}}/challenges?sort=start_date
+
+### Sort the challenges by end date (desc by default)
+
+GET {{basePath}}/challenges?sort=end_date
 
 ### Get one random challenge
 

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSortDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSortDto.java
@@ -15,7 +15,11 @@ public enum ChallengeSortDto {
 
   RELEVANCE("relevance"),
 
-  STARRED("starred");
+  STARRED("starred"),
+
+  START_DATE("start_date"),
+
+  END_DATE("end_date");
 
   private String value;
 

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeRepositoryImpl.java
@@ -367,24 +367,18 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
       case RANDOM -> {
         return scoreSort;
       }
-        // case RECENTLY_ENDED -> {
-        //   return sf.field("end_date").order(orderWithDefaultDesc).toSort();
-        // }
-        // case RECENTLY_STARTED -> {
-        //   return sf.field("start_date").order(orderWithDefaultDesc).toSort();
-        // }
+      case START_DATE -> {
+        return sf.field("end_date").order(orderWithDefaultDesc).toSort();
+      }
+      case END_DATE -> {
+        return sf.field("start_date").order(orderWithDefaultDesc).toSort();
+      }
       case RELEVANCE -> {
         return relevanceSort;
       }
       case STARRED -> {
         return sf.field("starred_count").order(orderWithDefaultDesc).toSort();
       }
-        // case STARTING_SOON -> {
-        //   return sf.field("start_date").order(orderWithDefaultAsc).toSort();
-        // }
-        // case ENDING_SOON -> {
-        //   return sf.field("end_date").order(orderWithDefaultAsc).toSort();
-        // }
       default -> {
         throw new BadRequestException(
             String.format("Unhandled sorting strategy '%s'", query.getSort()));
@@ -416,34 +410,6 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
                     + "}")
             .toPredicate();
       }
-        // case RECENTLY_ENDED -> {
-        //   SearchPredicate datePredicate =
-        //       pf.range().field("end_date").between(lastQuarter, now).toPredicate();
-        //   SearchPredicate statusPredicate =
-        //       pf.match().field("status").matching("completed").toPredicate();
-        //   return pf.bool(b -> b.must(datePredicate).must(statusPredicate)).toPredicate();
-        // }
-        // case RECENTLY_STARTED -> {
-        //   SearchPredicate datePredicate =
-        //       pf.range().field("start_date").between(lastQuarter, now).toPredicate();
-        //   SearchPredicate statusPredicate =
-        //       pf.match().field("status").matching("active").toPredicate();
-        //   return pf.bool(b -> b.must(datePredicate).must(statusPredicate)).toPredicate();
-        // }
-        // case STARTING_SOON -> {
-        //   SearchPredicate datePredicate =
-        //       pf.range().field("start_date").between(now, nextQuater).toPredicate();
-        //   SearchPredicate statusPredicate =
-        //       pf.match().field("status").matching("upcoming").toPredicate();
-        //   return pf.bool(b -> b.must(datePredicate).must(statusPredicate)).toPredicate();
-        // }
-        // case ENDING_SOON -> {
-        //   SearchPredicate datePredicate =
-        //       pf.range().field("end_date").between(now, nextQuater).toPredicate();
-        //   SearchPredicate statusPredicate =
-        //       pf.match().field("status").matching("active").toPredicate();
-        //   return pf.bool(b -> b.must(datePredicate).must(statusPredicate)).toPredicate();
-        // }
       default -> {
         return null;
       }

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -355,6 +355,8 @@ components:
       - random
       - relevance
       - starred
+      - start_date
+      - end_date
       type: string
     ChallengeDirection:
       description: The direction to sort the results by.

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -169,6 +169,8 @@ components:
         - random
         - relevance
         - starred
+        - start_date
+        - end_date
     ChallengeDirection:
       description: The direction to sort the results by.
       type: string

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -319,6 +319,8 @@ components:
         - random
         - relevance
         - starred
+        - start_date
+        - end_date
     ChallengeDirection:
       description: The direction to sort the results by.
       type: string

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
@@ -6,3 +6,5 @@ enum:
   - random
   - relevance
   - starred
+  - start_date
+  - end_date


### PR DESCRIPTION
## Changelog

- add `start_date` and `end_date` sorters (desc by default)

```console
GET {{basePath}}/challenges?sort=start_date

HTTP/1.1 200 
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 28 Sep 2023 01:44:24 GMT
Connection: close

{
  "number": 0,
  "size": 100,
  "totalElements": 232,
  "totalPages": 3,
  "hasNext": true,
  "hasPrevious": false,
  "challenges": [
    {
      "id": 195,
      "startDate": null,
      "endDate": "2023-12-31",
      ...
    },
    {
      "id": 232,
      "startDate": "2023-10-19",
      "endDate": "2023-10-21",
      ...
    },
    {
      "id": 177,
      "startDate": "2023-07-26",
      "endDate": "2023-10-13",
      ...
    },
    ...
}

```